### PR TITLE
Disable autoplay for mobile HTML file

### DIFF
--- a/examples/src/player.html
+++ b/examples/src/player.html
@@ -24,7 +24,7 @@
             height: 400,
             width: 600,
             videoId,
-            autoplay: true,
+            autoplay: false,
             controls: false,
             fullscreenEnabled: false,
             playsInline: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honor-ed-video-adaptors",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "A library comprised of adapters for easy embedding of common video players (e.g. Youtube, Vimeo) for use in both iOS and TypeScript projects",
   "author": "Calvin Collins (Honor Education)",
   "private": false,
@@ -39,8 +39,12 @@
   "files": [
     "dist"
   ],
-  "nodemonConfig": { 
-    "ignore": ["**/Tests/**", "**/dist/**", "**/Resources/**"],
+  "nodemonConfig": {
+    "ignore": [
+      "**/Tests/**",
+      "**/dist/**",
+      "**/Resources/**"
+    ],
     "watch": "src",
     "exec": "npm run build",
     "ext": "ts"

--- a/src/HonorPlayer.html
+++ b/src/HonorPlayer.html
@@ -19,7 +19,7 @@
             height: document.documentElement.clientHeight,
             width: document.documentElement.clientWidth,
             videoId,
-            autoplay: true,
+            autoplay: false,
             controls: false,
             fullscreenEnabled: false,
             playsInline: false,


### PR DESCRIPTION
Mobile has their own logic to handle autoplay -- would rather have the client call the methods on the player instead of hardcoding a true/false value, single responsibility, etc.